### PR TITLE
13 copyright header and open source license setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .env
-app/__pycache__/
+app/routes/__pycache__/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Hackerbot Industries LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script initializes the Flask application.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 from flask import Flask, g
 from flask_cors import CORS
 from app.routes import register_routes

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script contains the configuration for the Flask application.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 import os
 from dotenv import load_dotenv
 

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script registers the routes for the Flask application.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 from app.routes import status
 from app.routes import mapping
 from app.routes import action

--- a/app/routes/action.py
+++ b/app/routes/action.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script contains the action API endpoints.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 from flask import Blueprint, jsonify, current_app
 
 bp = Blueprint('action', __name__)

--- a/app/routes/mapping.py
+++ b/app/routes/mapping.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script contains the mapping API endpoints.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 from flask import Blueprint, jsonify, current_app, request
 
 bp = Blueprint('mapping_data', __name__)

--- a/app/routes/status.py
+++ b/app/routes/status.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script contains the status API endpoints.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 from flask import Blueprint, jsonify, current_app
 
 bp = Blueprint('status', __name__)

--- a/app/run.py
+++ b/app/run.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script runs the Flask application.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 from app import create_app
 
 app = create_app()

--- a/launch_flask_api.sh
+++ b/launch_flask_api.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script launches the Hackerbot Flask API process and occupies the serial port.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 set -o pipefail
 
 BASE_DIR="$(pwd)"

--- a/stop_flask_api.sh
+++ b/stop_flask_api.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script stops the Hackerbot Flask API process and releases the serial port.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
 
 # Ports for Flask and React
 FLASK_PORT=5000

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script tests the action API endpoints.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 import unittest
 from unittest.mock import MagicMock
 from flask import Flask

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script tests the mapping API endpoints.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 import unittest
 from unittest.mock import MagicMock
 from flask import Flask, jsonify

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (c) 2025 Hackerbot Industries LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Created By: Allen Chien
+# Created:    April 2025
+# Updated:    2025.04.01
+#
+# This script tests the status API endpoints.
+#
+# Special thanks to the following for their code contributions to this codebase:
+# Allen Chien - https://github.com/AllenChienXXX
+################################################################################
+
+
 import unittest
 from unittest.mock import MagicMock
 from flask import Flask, jsonify, current_app


### PR DESCRIPTION
**Description**

This pull request is to update the headers for each source files, and update the license to MIT. 

**Tasks**
- [ ] Update all source files with the proper header (Including source files in hackerbot_modules, example and keyboard_teleop_examples folder).
- [ ] Update repository license to MIT

**How to check locally**
- On your hackerbot, ssh to your raspberry pi or open VNC viewer
- Cloned this repository if not exist. `git clone https://github.com/hackerbotindustries/hackerbot-flask-api.git`
- Navigate to the directory: `cd ~/hackerbot/hackerbot-flask-api`
- Switch to this branch: 
```shell
git fetch
git checkout 13-copyright-header-and-open-source-license-setup
git pull
``` 
- Go through files changed in your editor to see if the copy right header is correctly implemented.
- [ ] Source files in `app/`
- [ ] Source files in `app/routes/`
- [ ] Source files in `tests/` 
- See if the license is correctly updated by viewing:
- [ ] LICENSE